### PR TITLE
Updating mxnet-cu101mkl import

### DIFF
--- a/notebooks/MLA-CV-Lecture1-CNN.ipynb
+++ b/notebooks/MLA-CV-Lecture1-CNN.ipynb
@@ -114,7 +114,7 @@
     }
    ],
    "source": [
-    "! pip install -q -U mxnet-cu101mkl==1.6.0\n",
+    "! pip install -U mxnet-cu101mkl==1.6.0.post0\n",
     "! pip install -q d2l==0.14.0"
    ]
   },

--- a/notebooks/MLA-CV-Lecture1-Final-Project.ipynb
+++ b/notebooks/MLA-CV-Lecture1-Final-Project.ipynb
@@ -41,7 +41,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ! pip install -q -U mxnet-cu101mkl==1.6.0  # updating mxnet to at least v1.6\n",
+    "# ! pip install -U mxnet-cu101mkl==1.6.0.post0  # updating mxnet to at least v1.6\n",
     "# ! pip install -q d2l==0.14.0"
    ]
   },

--- a/notebooks/MLA-CV-Lecture2-AlexNet.ipynb
+++ b/notebooks/MLA-CV-Lecture2-AlexNet.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# !pip install -q -U mxnet-cu101mkl==1.6.0  # updating mxnet to at least v1.6\n",
+    "# !pip install -U mxnet-cu101mkl==1.6.0.post0  # updating mxnet to at least v1.6\n",
     "# !pip install d2l==0.14.0"
    ]
   },

--- a/notebooks/MLA-CV-Lecture3-ResNet.ipynb
+++ b/notebooks/MLA-CV-Lecture3-ResNet.ipynb
@@ -46,7 +46,7 @@
     }
    ],
    "source": [
-    "# ! pip install -q -U mxnet-cu101mkl==1.6.0\n",
+    "# ! pip install -U mxnet-cu101mkl==1.6.0.post0\n",
     "# ! pip install -q d2l==0.14.0\n",
     "! pip install -q gluoncv"
    ]


### PR DESCRIPTION
MXNet library import correction. Changed from `mxnet-cu101mkl==1.6.0` to `mxnet-cu101mkl==1.6.0.post0`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
